### PR TITLE
Fix ChatModel constant

### DIFF
--- a/src/main/java/com/github/sharifrahim/chatgpt/chatgpt/integration/demo/service/impl/ChatGptServiceImpl.java
+++ b/src/main/java/com/github/sharifrahim/chatgpt/chatgpt/integration/demo/service/impl/ChatGptServiceImpl.java
@@ -62,9 +62,9 @@ public class ChatGptServiceImpl implements ChatGptService {
         ChatCompletionCreateParams params = ChatCompletionCreateParams.builder()
             .addUserMessage(userMessage)
             .addSystemMessage("Response in this json format : " + exampleJsonFormat + ". Only output JSON.")
-            .model(ChatModel.GPT_4O_2024_11_20)
+            .model(ChatModel.GPT_3_5_TURBO)
             .build();
-        log.info("ChatCompletionCreateParams built with model: {}", ChatModel.GPT_4O_2024_11_20);
+        log.info("ChatCompletionCreateParams built with model: {}", ChatModel.GPT_3_5_TURBO);
 
         // Send the request using the OpenAI client and receive the chat completion.
         ChatCompletion chatCompletion = openAiClient.chat().completions().create(params);


### PR DESCRIPTION
## Summary
- use `ChatModel.GPT_3_5_TURBO` instead of deprecated constant

## Testing
- `mvnw -q test` *(fails: Failed to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684c446af8548323ae49c6e7d51e6f82