### PR TITLE
Fix field name for sunnah reference link

### DIFF
--- a/src/main/java/com/github/sharifrahim/chatgpt/chatgpt/integration/demo/controller/TimelineApiController.java
+++ b/src/main/java/com/github/sharifrahim/chatgpt/chatgpt/integration/demo/controller/TimelineApiController.java
@@ -94,7 +94,7 @@ public class TimelineApiController {
                 eventDetail.getOrigin(),
                 eventDetail.getOriginRefLink(),
                 eventDetail.getSunnah(),
-                eventDetail.getSunnahRefLInk()
+                eventDetail.getSunnahRefLink()
         );
         
         // Log completion of the detailed event information retrieval

--- a/src/main/java/com/github/sharifrahim/chatgpt/chatgpt/integration/demo/dto/IslamicEventDetailDTO.java
+++ b/src/main/java/com/github/sharifrahim/chatgpt/chatgpt/integration/demo/dto/IslamicEventDetailDTO.java
@@ -41,5 +41,5 @@ public class IslamicEventDetailDTO {
     /**
      * The reference link providing additional details about the sunnah.
      */
-    private String sunnahRefLInk;
+    private String sunnahRefLink;
 }


### PR DESCRIPTION
## Summary
- rename field to `sunnahRefLink` in `IslamicEventDetailDTO`
- call new getter `getSunnahRefLink()` in `TimelineApiController`

## Testing
- `./mvnw -q test` *(fails: Could not fetch Maven due to no internet)*

------
https://chatgpt.com/codex/tasks/task_e_684c445fc9288323bc9ccd7da6a06070