### PR TITLE
Refactor package naming

### DIFF
--- a/src/main/java/com/github/sharifrahim/chatgptintegration/demo/ChatgptIntegrationDemoApplication.java
+++ b/src/main/java/com/github/sharifrahim/chatgptintegration/demo/ChatgptIntegrationDemoApplication.java
@@ -1,4 +1,4 @@
-package com.github.sharifrahim.chatgpt.chatgpt.integration.demo;
+package com.github.sharifrahim.chatgptintegration.demo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/src/main/java/com/github/sharifrahim/chatgptintegration/demo/config/OpenAIConfig.java
+++ b/src/main/java/com/github/sharifrahim/chatgptintegration/demo/config/OpenAIConfig.java
@@ -1,4 +1,4 @@
-package com.github.sharifrahim.chatgpt.chatgpt.integration.demo.config;
+package com.github.sharifrahim.chatgptintegration.demo.config;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/com/github/sharifrahim/chatgptintegration/demo/controller/TimelineApiController.java
+++ b/src/main/java/com/github/sharifrahim/chatgptintegration/demo/controller/TimelineApiController.java
@@ -1,4 +1,4 @@
-package com.github.sharifrahim.chatgpt.chatgpt.integration.demo.controller;
+package com.github.sharifrahim.chatgptintegration.demo.controller;
 
 import java.util.List;
 
@@ -8,12 +8,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.github.sharifrahim.chatgpt.chatgpt.integration.demo.dto.IslamicEventDetailDTO;
-import com.github.sharifrahim.chatgpt.chatgpt.integration.demo.dto.TimelineDetailDTO;
-import com.github.sharifrahim.chatgpt.chatgpt.integration.demo.dto.TimelineItemDTO;
-import com.github.sharifrahim.chatgpt.chatgpt.integration.demo.service.ChatGptService;
-import com.github.sharifrahim.chatgpt.chatgpt.integration.demo.service.IslamicEventService;
-import com.github.sharifrahim.chatgpt.chatgpt.integration.demo.strategy.impl.IslamicEvent;
+import com.github.sharifrahim.chatgptintegration.demo.dto.IslamicEventDetailDTO;
+import com.github.sharifrahim.chatgptintegration.demo.dto.TimelineDetailDTO;
+import com.github.sharifrahim.chatgptintegration.demo.dto.TimelineItemDTO;
+import com.github.sharifrahim.chatgptintegration.demo.service.ChatGptService;
+import com.github.sharifrahim.chatgptintegration.demo.service.IslamicEventService;
+import com.github.sharifrahim.chatgptintegration.demo.strategy.impl.IslamicEvent;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/github/sharifrahim/chatgptintegration/demo/controller/TimelineController.java
+++ b/src/main/java/com/github/sharifrahim/chatgptintegration/demo/controller/TimelineController.java
@@ -1,4 +1,4 @@
-package com.github.sharifrahim.chatgpt.chatgpt.integration.demo.controller;
+package com.github.sharifrahim.chatgptintegration.demo.controller;
 
 import java.time.LocalDate;
 import java.time.chrono.HijrahDate;
@@ -8,11 +8,11 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 
-import com.github.sharifrahim.chatgpt.chatgpt.integration.demo.dto.HadithOfTheDayDTO;
-import com.github.sharifrahim.chatgpt.chatgpt.integration.demo.dto.QuranOfTheDayDTO;
-import com.github.sharifrahim.chatgpt.chatgpt.integration.demo.service.ChatGptService;
-import com.github.sharifrahim.chatgpt.chatgpt.integration.demo.strategy.impl.HadithOfTheDayStrategy;
-import com.github.sharifrahim.chatgpt.chatgpt.integration.demo.strategy.impl.QuranOfTheDay;
+import com.github.sharifrahim.chatgptintegration.demo.dto.HadithOfTheDayDTO;
+import com.github.sharifrahim.chatgptintegration.demo.dto.QuranOfTheDayDTO;
+import com.github.sharifrahim.chatgptintegration.demo.service.ChatGptService;
+import com.github.sharifrahim.chatgptintegration.demo.strategy.impl.HadithOfTheDayStrategy;
+import com.github.sharifrahim.chatgptintegration.demo.strategy.impl.QuranOfTheDay;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/github/sharifrahim/chatgptintegration/demo/dto/HadithOfTheDayDTO.java
+++ b/src/main/java/com/github/sharifrahim/chatgptintegration/demo/dto/HadithOfTheDayDTO.java
@@ -1,4 +1,4 @@
-package com.github.sharifrahim.chatgpt.chatgpt.integration.demo.dto;
+package com.github.sharifrahim.chatgptintegration.demo.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src/main/java/com/github/sharifrahim/chatgptintegration/demo/dto/IslamicEventDetailDTO.java
+++ b/src/main/java/com/github/sharifrahim/chatgptintegration/demo/dto/IslamicEventDetailDTO.java
@@ -1,4 +1,4 @@
-package com.github.sharifrahim.chatgpt.chatgpt.integration.demo.dto;
+package com.github.sharifrahim.chatgptintegration.demo.dto;
 
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/github/sharifrahim/chatgptintegration/demo/dto/QuranOfTheDayDTO.java
+++ b/src/main/java/com/github/sharifrahim/chatgptintegration/demo/dto/QuranOfTheDayDTO.java
@@ -1,4 +1,4 @@
-package com.github.sharifrahim.chatgpt.chatgpt.integration.demo.dto;
+package com.github.sharifrahim.chatgptintegration.demo.dto;
 
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/github/sharifrahim/chatgptintegration/demo/dto/TimelineDetailDTO.java
+++ b/src/main/java/com/github/sharifrahim/chatgptintegration/demo/dto/TimelineDetailDTO.java
@@ -1,4 +1,4 @@
-package com.github.sharifrahim.chatgpt.chatgpt.integration.demo.dto;
+package com.github.sharifrahim.chatgptintegration.demo.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src/main/java/com/github/sharifrahim/chatgptintegration/demo/dto/TimelineItemDTO.java
+++ b/src/main/java/com/github/sharifrahim/chatgptintegration/demo/dto/TimelineItemDTO.java
@@ -1,4 +1,4 @@
-package com.github.sharifrahim.chatgpt.chatgpt.integration.demo.dto;
+package com.github.sharifrahim.chatgptintegration.demo.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src/main/java/com/github/sharifrahim/chatgptintegration/demo/service/ChatGptService.java
+++ b/src/main/java/com/github/sharifrahim/chatgptintegration/demo/service/ChatGptService.java
@@ -1,4 +1,4 @@
-package com.github.sharifrahim.chatgpt.chatgpt.integration.demo.service;
+package com.github.sharifrahim.chatgptintegration.demo.service;
 
 /**
  * Service interface for interacting with ChatGPT.

--- a/src/main/java/com/github/sharifrahim/chatgptintegration/demo/service/IslamicEventService.java
+++ b/src/main/java/com/github/sharifrahim/chatgptintegration/demo/service/IslamicEventService.java
@@ -1,4 +1,4 @@
-package com.github.sharifrahim.chatgpt.chatgpt.integration.demo.service;
+package com.github.sharifrahim.chatgptintegration.demo.service;
 
 import java.time.LocalDate;
 import java.time.chrono.HijrahDate;
@@ -9,7 +9,7 @@ import java.util.List;
 
 import org.springframework.stereotype.Service;
 
-import com.github.sharifrahim.chatgpt.chatgpt.integration.demo.dto.TimelineItemDTO;
+import com.github.sharifrahim.chatgptintegration.demo.dto.TimelineItemDTO;
 
 import lombok.extern.slf4j.Slf4j;
 

--- a/src/main/java/com/github/sharifrahim/chatgptintegration/demo/service/impl/ChatGptServiceImpl.java
+++ b/src/main/java/com/github/sharifrahim/chatgptintegration/demo/service/impl/ChatGptServiceImpl.java
@@ -1,9 +1,9 @@
-package com.github.sharifrahim.chatgpt.chatgpt.integration.demo.service.impl;
+package com.github.sharifrahim.chatgptintegration.demo.service.impl;
 
 import org.springframework.stereotype.Service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.sharifrahim.chatgpt.chatgpt.integration.demo.service.ChatGptService;
+import com.github.sharifrahim.chatgptintegration.demo.service.ChatGptService;
 import com.openai.client.OpenAIClient;
 import com.openai.models.ChatCompletion;
 import com.openai.models.ChatCompletionCreateParams;

--- a/src/main/java/com/github/sharifrahim/chatgptintegration/demo/strategy/MessageStrategy.java
+++ b/src/main/java/com/github/sharifrahim/chatgptintegration/demo/strategy/MessageStrategy.java
@@ -1,4 +1,4 @@
-package com.github.sharifrahim.chatgpt.chatgpt.integration.demo.strategy;
+package com.github.sharifrahim.chatgptintegration.demo.strategy;
 
 /**
  * Strategy interface for defining message behavior for ChatGPT interactions.

--- a/src/main/java/com/github/sharifrahim/chatgptintegration/demo/strategy/impl/HadithOfTheDayStrategy.java
+++ b/src/main/java/com/github/sharifrahim/chatgptintegration/demo/strategy/impl/HadithOfTheDayStrategy.java
@@ -1,7 +1,7 @@
-package com.github.sharifrahim.chatgpt.chatgpt.integration.demo.strategy.impl;
+package com.github.sharifrahim.chatgptintegration.demo.strategy.impl;
 
-import com.github.sharifrahim.chatgpt.chatgpt.integration.demo.dto.HadithOfTheDayDTO;
-import com.github.sharifrahim.chatgpt.chatgpt.integration.demo.strategy.MessageStrategy;
+import com.github.sharifrahim.chatgptintegration.demo.dto.HadithOfTheDayDTO;
+import com.github.sharifrahim.chatgptintegration.demo.strategy.MessageStrategy;
 
 /**
  * Strategy implementation for fetching the Hadith of the Day.

--- a/src/main/java/com/github/sharifrahim/chatgptintegration/demo/strategy/impl/IslamicEvent.java
+++ b/src/main/java/com/github/sharifrahim/chatgptintegration/demo/strategy/impl/IslamicEvent.java
@@ -1,7 +1,7 @@
-package com.github.sharifrahim.chatgpt.chatgpt.integration.demo.strategy.impl;
+package com.github.sharifrahim.chatgptintegration.demo.strategy.impl;
 
-import com.github.sharifrahim.chatgpt.chatgpt.integration.demo.dto.IslamicEventDetailDTO;
-import com.github.sharifrahim.chatgpt.chatgpt.integration.demo.strategy.MessageStrategy;
+import com.github.sharifrahim.chatgptintegration.demo.dto.IslamicEventDetailDTO;
+import com.github.sharifrahim.chatgptintegration.demo.strategy.MessageStrategy;
 
 import lombok.Setter;
 

--- a/src/main/java/com/github/sharifrahim/chatgptintegration/demo/strategy/impl/QuranOfTheDay.java
+++ b/src/main/java/com/github/sharifrahim/chatgptintegration/demo/strategy/impl/QuranOfTheDay.java
@@ -1,7 +1,7 @@
-package com.github.sharifrahim.chatgpt.chatgpt.integration.demo.strategy.impl;
+package com.github.sharifrahim.chatgptintegration.demo.strategy.impl;
 
-import com.github.sharifrahim.chatgpt.chatgpt.integration.demo.dto.QuranOfTheDayDTO;
-import com.github.sharifrahim.chatgpt.chatgpt.integration.demo.strategy.MessageStrategy;
+import com.github.sharifrahim.chatgptintegration.demo.dto.QuranOfTheDayDTO;
+import com.github.sharifrahim.chatgptintegration.demo.strategy.MessageStrategy;
 
 /**
  * Strategy implementation for fetching the Quran of the Day.

--- a/src/test/java/com/github/sharifrahim/chatgptintegration/demo/ChatgptIntegrationDemoApplicationTests.java
+++ b/src/test/java/com/github/sharifrahim/chatgptintegration/demo/ChatgptIntegrationDemoApplicationTests.java
@@ -1,4 +1,4 @@
-package com.github.sharifrahim.chatgpt.chatgpt.integration.demo;
+package com.github.sharifrahim.chatgptintegration.demo;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;


### PR DESCRIPTION
## Summary
- collapse redundant `chatgpt.chatgpt.integration` package to `chatgptintegration`
- update imports and package declarations

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_684c48e466fc8323a9f25f5cc16071cf